### PR TITLE
Prevent error on unload when project instance is not set

### DIFF
--- a/trackable_project_files/__init__.py
+++ b/trackable_project_files/__init__.py
@@ -31,4 +31,6 @@ class StableProjectFile:
         self.project_saved_connection = QgsProject.instance().projectSaved.connect(self.normalize_xml)
 
     def unload(self):
-        QgsProject.instance().projectSaved.disconnect(self.project_saved_connection)
+        p = QgsProject.instance()
+        if p and self.project_saved_connection:
+            p.projectSaved.disconnect(self.project_saved_connection)


### PR DESCRIPTION
When you open QGIS, and then add layers to a unsaved project, the property self.project_saved_connection is not set