### PR TITLE
Ignore non local filesystem storages

### DIFF
--- a/trackable_project_files/__init__.py
+++ b/trackable_project_files/__init__.py
@@ -29,6 +29,10 @@ class StableProjectFile:
         if project.isZipped():
             return
 
+        # Anything but local files will return a pointer to the storage
+        if project.projectStorage():
+            return
+
         fn = project.fileName()
         with open(fn, 'r') as file:
             et = ET.parse(file)


### PR DESCRIPTION
Fixes #3 . Not the perfect solution, but I guess the majority of the userbase of this plugin want to store their projects in text `.qgs` files, not within some fancy storage.